### PR TITLE
fix: use coundown example rerender bug

### DIFF
--- a/.prettier.js
+++ b/.prettier.js
@@ -1,6 +1,6 @@
 module.exports = {
   semi: true,
-  singleQuote: true,
-  trailingComma: "all",
-  arrowParens: "avoid",
+  singleQuote: false,
+  trailingComma: 'all',
+  arrowParens: 'avoid',
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": 'all',
+  "arrowParens": 'avoid',
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,4 +3,4 @@
   "singleQuote": false,
   "trailingComma": 'all',
   "arrowParens": 'avoid',
-};
+}

--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,4 +1,5 @@
 {
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  // "editor.formatOnSave": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.singleQuote": false
 }

--- a/lib/hooks/useCountdown.ts
+++ b/lib/hooks/useCountdown.ts
@@ -43,6 +43,10 @@ function getCurrentStatus(time: number, start: number, end: number) {
   return TimeStatus.Ongoing;
 }
 
+/**
+ *
+ * when you use this hook, outside component should use React.memo() to prevent rerender.
+ */
 export const useCountdown = (
   start: number,
   end: number,
@@ -51,12 +55,12 @@ export const useCountdown = (
   const timer = useRef(0);
   const [currentTime, setCurrentTime] = useState(now() * 1000);
 
-  const getCurrentTime = useCallback(() => {
+  const getCurrentTime = () => {
     if (currentTime > start && currentTime < end) {
       setCurrentTime(now() * 1000);
       requestAnimationFrame(getCurrentTime);
     }
-  }, [currentTime, end, start]);
+  };
 
   useEffect(() => {
     timer.current = requestAnimationFrame(getCurrentTime);
@@ -67,24 +71,20 @@ export const useCountdown = (
 
   const countdownTime = end - currentTime;
   const defaultCountdownTime = end - start;
+  const status = getCurrentStatus(currentTime, start, end);
 
-  const currentStatus = getCurrentStatus(currentTime, start, end);
+  let text;
+  if (status === TimeStatus.NotYet) {
+    text = formatCountdownText(getRelatedDistance(defaultCountdownTime));
+  } else if (status === TimeStatus.Ongoing) {
+    text = formatCountdownText(getRelatedDistance(countdownTime));
+  } else {
+    text = timeEndText;
+  }
 
-  if (currentStatus === TimeStatus.NotYet) {
-    return {
-      status: currentStatus,
-      text: formatCountdownText(getRelatedDistance(defaultCountdownTime)),
-    };
-  }
-  if (currentStatus === TimeStatus.Ongoing) {
-    return {
-      status: currentStatus,
-      text: formatCountdownText(getRelatedDistance(countdownTime)),
-    };
-  }
   return {
-    status: currentStatus,
-    text: timeEndText,
+    status,
+    text,
   };
 };
 

--- a/lib/hooks/usePageData.ts
+++ b/lib/hooks/usePageData.ts
@@ -16,6 +16,10 @@ export interface PageContext {
   init: boolean;
 }
 
+/**
+ *
+ * when you use this hook, outside component should use React.memo() to prevent rerender. (trigger by useCountdown)
+ */
 export const usePageData = ({
   startDate,
   endDate,

--- a/playground/OfflineRound.tsx
+++ b/playground/OfflineRound.tsx
@@ -58,4 +58,4 @@ const OfflineRound = () => {
   );
 };
 
-export default OfflineRound;
+export default React.memo(OfflineRound);


### PR DESCRIPTION
before:
![chrome-capture (2)](https://user-images.githubusercontent.com/10138764/124239670-862c9c00-db4c-11eb-97cd-f52aab296c61.gif)
after:
![chrome-capture (3)](https://user-images.githubusercontent.com/10138764/124239693-8af15000-db4c-11eb-9e63-d63e8ffc2e7f.gif)

sample 希望完美點

增加 hook 引用時說明, 移除不必要的 useCallback.

另外不知為何吃不到 .prettier.js, 我一直有 single/double quote 問題 (目前看起來專案都適用 double quote) 先關掉＆增加 .prettierrc 後就吃得到了@@ 