### PR TITLE
[APP-26888] i18n functions

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -57,6 +57,9 @@ export function debounce<Params extends any[]>(
   };
 }
 
+/**
+ * Get browser languages or manually queryString. e.g. ?lang=ja
+ */
 export const getUserLangs = (): string[] => {
   const q = qs<{ lang: string }>();
   return Array.from(
@@ -66,6 +69,9 @@ export const getUserLangs = (): string[] => {
   );
 };
 
+/**
+ * languages defined from Eventory
+ */
 export enum RegionLanguage {
   TAIWAN = 'zh_TW',
   CHINA = 'zh_CN',
@@ -75,11 +81,17 @@ export enum RegionLanguage {
   ARAB = 'ar',
 }
 
-export const getCurrentTransLateLang = (
+/**
+ * Get Currently selected language from campaign setting
+ * @param {RegionLanguage[]} supportLangs languages provide by campaign setting
+ * @returns {RegionLanguage}
+ */
+export const getCurrentTranslateLang = (
   supportLangs: RegionLanguage[],
 ): string => {
+  const defaultLang = RegionLanguage.TAIWAN;
   if (supportLangs.length <= 0) {
-    return RegionLanguage.TAIWAN;
+    return defaultLang;
   }
 
   const isSupportHant =
@@ -110,7 +122,7 @@ export const getCurrentTransLateLang = (
   let currentLang = '';
 
   userLangList.forEach(lang => {
-    if (currentLang === '') {
+    if (!currentLang) {
       if (lang === 'zh') {
         if (isSupportHant) {
           const matchedLang = userLangList.find(userlang =>
@@ -120,8 +132,8 @@ export const getCurrentTransLateLang = (
           if (matchedLang) {
             currentLang = matchedLang;
           } else {
-            const [defaultLang] = supportHantLangList;
-            currentLang = defaultLang;
+            const [defaultHant] = supportHantLangList;
+            currentLang = defaultHant;
           }
         }
       } else {
@@ -134,5 +146,5 @@ export const getCurrentTransLateLang = (
     }
   });
 
-  return currentLang || RegionLanguage.TAIWAN;
+  return currentLang || defaultLang;
 };

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -4,6 +4,7 @@ import OfflineTeamRound from './OfflineTeamRound';
 import LuckyDraw from './LuckyDraw';
 import TypeApi from './TypeApi';
 import Filter from './Filter';
+import Utils from './Utils';
 
 const App = () => {
   const [currentComponent, setCurrentComponent] =
@@ -17,6 +18,7 @@ const App = () => {
     offlineTeamRound: <OfflineTeamRound />,
     typeApi: <TypeApi />,
     filter: <Filter />,
+    utils: <Utils />,
   };
 
   return (

--- a/playground/Utils.tsx
+++ b/playground/Utils.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useMemo } from 'react';
+import styled from 'styled-components';
+import {
+  getUserLangs,
+  getCurrentTransLateLang,
+  RegionLanguage,
+} from '../lib/utils';
+
+const DisplayResult = styled.span`
+  &:before {
+    content: 'return value:';
+    display: block;
+  }
+  display: inline-block;
+  background-color: #cccccc;
+  padding: 5px 10px;
+`;
+
+const Checkbox = styled.input`
+  margin-right: 20px;
+  padding: 5px 10px 5px 0;
+`;
+
+const Utils = () => {
+  const [supportLangs, setSupportLangs] = useState<RegionLanguage[]>([
+    RegionLanguage.JAPAN,
+  ]);
+
+  const onChangeHandler = e => {
+    const { value: selectedLang, checked: isChecked } = e.target;
+    if (isChecked) {
+      setSupportLangs(preValue => [selectedLang, ...preValue]);
+    } else {
+      if (supportLangs.length <= 1) {
+        alert('should be keep at least one support language');
+        return;
+      }
+      setSupportLangs(preValue => preValue.filter(v => v !== selectedLang));
+    }
+  };
+
+  const allSupportLanguages = [
+    RegionLanguage.TAIWAN,
+    RegionLanguage.CHINA,
+    RegionLanguage.HONGKONG,
+    RegionLanguage.JAPAN,
+    RegionLanguage.EUROPE,
+    RegionLanguage.ARAB,
+  ];
+
+  const currentTransLateLang = useMemo(
+    () => getCurrentTransLateLang(supportLangs),
+    [supportLangs],
+  );
+
+  return (
+    <div>
+      <h1>Utils</h1>
+      <h2>i18n</h2>
+      <h3>getUserLangs</h3>
+      <p>Get browser languages or manually queryString. e.g. ?lang=ja</p>
+      <br />
+      <DisplayResult>{JSON.stringify(getUserLangs())}</DisplayResult>
+      <h3>getCurrentTransLateLang</h3>
+      <p>這個方法可以拿到前端要顯示的語系</p>
+      <span>eventory 支援語系: </span>
+      {allSupportLanguages.map(langCode => (
+        <>
+          <span>{langCode}</span>
+          <Checkbox
+            type="checkbox"
+            value={langCode}
+            onChange={onChangeHandler}
+            checked={supportLangs.includes(langCode)}
+          />
+        </>
+      ))}
+      <br />
+      <DisplayResult>{currentTransLateLang}</DisplayResult>
+    </div>
+  );
+};
+
+export default React.memo(Utils);

--- a/playground/Utils.tsx
+++ b/playground/Utils.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import styled from 'styled-components';
 import {
   getUserLangs,
-  getCurrentTransLateLang,
+  getCurrentTranslateLang,
   RegionLanguage,
 } from '../lib/utils';
 
@@ -49,7 +49,7 @@ const Utils = () => {
   ];
 
   const currentTransLateLang = useMemo(
-    () => getCurrentTransLateLang(supportLangs),
+    () => getCurrentTranslateLang(supportLangs),
     [supportLangs],
   );
 
@@ -61,7 +61,7 @@ const Utils = () => {
       <p>Get browser languages or manually queryString. e.g. ?lang=ja</p>
       <br />
       <DisplayResult>{JSON.stringify(getUserLangs())}</DisplayResult>
-      <h3>getCurrentTransLateLang</h3>
+      <h3>getCurrentTranslateLang</h3>
       <p>這個方法可以拿到前端要顯示的語系</p>
       <span>eventory 支援語系: </span>
       {allSupportLanguages.map(langCode => (

--- a/playground/Utils.tsx
+++ b/playground/Utils.tsx
@@ -48,10 +48,7 @@ const Utils = () => {
     RegionLanguage.ARAB,
   ];
 
-  const currentTransLateLang = useMemo(
-    () => getCurrentTranslateLang(supportLangs),
-    [supportLangs],
-  );
+  const currentTransLateLang = getCurrentTranslateLang(supportLangs);
 
   return (
     <div>


### PR DESCRIPTION

- 移植兩個方法

- 改寫 getCurrentTransLateLang
之前的方法一定要 default 有 zh_TW, 改成可以只拿 zh_CH, zh_HK
照順序優先度判斷語系


p.s.
統一一下不同瀏覽器拿到的字串
chrome 會直接有 `zh`, 所以還要去判斷除了 `zh` 以外的東西