### PR TITLE
[APP-35401] fix candidates are null bug

### DIFF
--- a/lib/hooks/useLuckyDraw.tsx
+++ b/lib/hooks/useLuckyDraw.tsx
@@ -60,8 +60,7 @@ export const useLuckyDraw: Props = (
   allCandidates,
   willAutoDrawRemainCount = true,
 ) => {
-  const sortAllCandidates = allCandidates.sort((a, b) => a.rank - b.rank);
-  const [candidates, setCandidates] = useState<User[]>(sortAllCandidates);
+  const [candidates, setCandidates] = useState<User[]>([]);
   const [winners, setWinners] = useState<User[]>([]);
   const [allWinners, setAllWinners] = useState<User[][]>([]);
   const [currentRound, setCurrentRound] = useState<number>(0);
@@ -140,17 +139,21 @@ export const useLuckyDraw: Props = (
   };
 
   useEffect(() => {
-    setCandidates(prev => {
+    if (currentRound !== 0) {
+      return;
+    }
+
+    setCandidates(prevCandidates => {
+      const sortAllCandidates = allCandidates.sort((a, b) => a.rank - b.rank);
       if (
-        JSON.stringify(prev) !== JSON.stringify(sortAllCandidates) &&
-        currentRound === 0
+        prevCandidates.length === 0 ||
+        JSON.stringify(prevCandidates) !== JSON.stringify(sortAllCandidates)
       ) {
         return sortAllCandidates;
       }
-      return prev;
+      return prevCandidates;
     });
-  }, [sortAllCandidates, currentRound]);
-
+  }, [allCandidates, currentRound]);
   return {
     candidates,
     hasDraw,

--- a/lib/hooks/useLuckyDraw.tsx
+++ b/lib/hooks/useLuckyDraw.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { User } from '../types';
 import { getRandomInteger, isBrowser, globalThis } from '../utils';
@@ -138,6 +138,18 @@ export const useLuckyDraw: Props = (
       localStorage.removeItem(globalThis.location.href);
     }
   };
+
+  useEffect(() => {
+    setCandidates(prev => {
+      if (
+        JSON.stringify(prev) !== JSON.stringify(sortAllCandidates) &&
+        currentRound === 0
+      ) {
+        return sortAllCandidates;
+      }
+      return prev;
+    });
+  }, [sortAllCandidates, currentRound]);
 
   return {
     candidates,


### PR DESCRIPTION
## Ticket

[APP-35401](https://17media.atlassian.net/browse/APP-35401)

## Implement
修正useLuckyDraw 如果在 init 時沒有傳入有value的leaderboardData時， candidates 會回傳空陣列問題